### PR TITLE
Fix Share single Arc<DBConn> across all threads

### DIFF
--- a/{{cookiecutter.repo_name}}/src/container.rs
+++ b/{{cookiecutter.repo_name}}/src/container.rs
@@ -14,14 +14,15 @@ pub struct Container {
 
 impl Container {
     pub fn new() -> Self {
+        let pool = Arc::new(db_pool());
         let todo_repository: Arc<dyn TodoRepository> = Arc::new(
-            TodoDieselRepository::new(Arc::new(db_pool()))
+            TodoDieselRepository::new(pool.clone())
         );
         let todo_service = Arc::new(
             TodoServiceImpl { repository: todo_repository }
         );
         let service_context_service = Arc::new(
-            ServiceContextServiceImpl::new(Arc::new(db_pool()))
+            ServiceContextServiceImpl::new(pool.clone())
         );
         Container { todo_service, service_context_service }
     }

--- a/{{cookiecutter.repo_name}}/src/create_app.rs
+++ b/{{cookiecutter.repo_name}}/src/create_app.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use actix_web::{App, web};
 use actix_web::{Error};
 use actix_web::body::MessageBody;
@@ -7,7 +8,7 @@ use crate::api::controllers::todo_handler::{create_todo_handler, delete_todo_han
 use crate::api::middleware::{ServiceContextMaintenanceCheck};
 use crate::container::Container;
 
-pub fn create_app() -> App<
+pub fn create_app(container: Arc<Container>) -> App<
     impl ServiceFactory<
         ServiceRequest,
         Response = ServiceResponse<impl MessageBody>,
@@ -16,7 +17,6 @@ pub fn create_app() -> App<
         Error = Error,
     >,
 > {
-    let container = Container::new();
     let todo_service = container.todo_service.clone();
     let service_context_service = container.service_context_service.clone();
 

--- a/{{cookiecutter.repo_name}}/src/domain/services/service_context.rs
+++ b/{{cookiecutter.repo_name}}/src/domain/services/service_context.rs
@@ -1,6 +1,6 @@
 use crate::domain::models::service_context::ServiceContext;
 
-pub trait ServiceContextService {
+pub trait ServiceContextService: 'static + Sync + Send {
     fn get_service_context(&self) -> ServiceContext;
     fn update(&self, service_context: ServiceContext) -> ServiceContext;
     fn is_maintenance_active(&self) -> bool;

--- a/{{cookiecutter.repo_name}}/src/domain/services/todo.rs
+++ b/{{cookiecutter.repo_name}}/src/domain/services/todo.rs
@@ -6,7 +6,7 @@ use crate::domain::repositories::repository::ResultPaging;
 use crate::domain::repositories::todo::TodoQueryParams;
 
 #[async_trait]
-pub trait TodoService: Sync + Send {
+pub trait TodoService: 'static + Sync + Send {
     async fn create(&self, todo: CreateTodo) -> Result<Todo, CommonError>;
     async fn list(&self, params: TodoQueryParams) -> Result<ResultPaging<Todo>, CommonError>;
     async fn get(&self, todo_id: i32) -> Result<Todo, CommonError>;

--- a/{{cookiecutter.repo_name}}/src/main.rs
+++ b/{{cookiecutter.repo_name}}/src/main.rs
@@ -1,5 +1,6 @@
+use std::sync::Arc;
 use actix_web::{HttpServer};
-use actix_clean_architecture::create_app::{create_app};
+use actix_clean_architecture::{container::Container, create_app::create_app};
 
 
 #[cfg(test)]
@@ -7,7 +8,8 @@ mod tests;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let server = HttpServer::new(move || { create_app() })
+    let container = Arc::new(Container::new());
+    let server = HttpServer::new(move || { create_app(container.clone()) })
     .bind(("127.0.0.1", 8080))?;
     server.run().await
 }

--- a/{{cookiecutter.repo_name}}/src/tests/api/test_todo_controllers.rs
+++ b/{{cookiecutter.repo_name}}/src/tests/api/test_todo_controllers.rs
@@ -10,7 +10,7 @@ mod test_todo_controllers{
     use actix_clean_architecture::infrastructure::databases::postgresql::db_pool;
     use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
     use serde_json::json;
-    use actix_clean_architecture::create_app::create_app;
+    use actix_clean_architecture::{container::Container, create_app::create_app};
     use actix_clean_architecture::domain::models::todo::Todo;
     use actix_clean_architecture::domain::repositories::repository::ResultPaging;
 
@@ -31,10 +31,14 @@ mod test_todo_controllers{
 
         env::set_var(POSTGRESQL_DB_URI, connection_string);
 
+        {
         let pool = Arc::new(db_pool());
         pool.get().unwrap().run_pending_migrations(MIGRATIONS).unwrap();
+        }
 
-        let app = test::init_service(create_app()).await;
+        let container = Arc::new(Container::new());
+
+        let app = test::init_service(create_app(container)).await;
         let request_body = json!({
             "title": "test todo",
             "description": "Test description"


### PR DESCRIPTION
In the previous implementation, the application created a new instance of the container for each thread. Inside each container, a separate database connection was established for every service. This approach led to a rapid increase in the number of open database connections, potentially exceeding the maximum limit allowed by PostgreSQL (96 connections)

To address this issue, the new implementation uses a shared Arc<DbConn> for database connections. All services and containers now use the same Arc<DbConn>, ensuring that the connection pool is shared and managed efficiently, preventing the risk of exceeding the maximum allowed connections.
![image](https://github.com/microsoft/cookiecutter-rust-actix-clean-architecture/assets/40138568/dfdaf584-690e-48c0-b954-2682fe9d6336)

